### PR TITLE
Build from base docker image and don't copy in node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,1 @@
-FROM node:alpine
-
-RUN mkdir -p /app
-WORKDIR /app
-COPY . /app
-
-RUN npm install
-
-CMD npm start
+FROM rabblerouser/node-base


### PR DESCRIPTION
Now using [this base image](https://hub.docker.com/r/rabblerouser/node-base/), from [this repo](https://github.com/rabblerouser/node-base-image).

This reduces copy-pasta effort as we add more services.

Also, don't mount `node_modules` from the host when building. Instead, install them fresh inside the container.